### PR TITLE
Reset Cache on muscle delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ node_modules
 
 venv-django/
 /.vscode/
+
+yarn.lock

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -76,6 +76,29 @@ class Muscle(models.Model):
         '''
         return False
 
+    def delete(self, *args, **kwargs):
+        """ Over rides the delete method of the muscle """
+
+        # reset the template cache
+        for language in Language.objects.all():
+            delete_template_fragment_cache('muscle-overview', language.id)
+            delete_template_fragment_cache('exercise-overview', language.id)
+            delete_template_fragment_cache('exercise-overview-mobile',language.id)
+            delete_template_fragment_cache('equipment-overview', language.id)
+            
+        
+        # get all exercises that train the muscle
+        exercizes = Exercise.objects.filter(muscles=self).iterator()
+
+        # delete exercises from the cache
+        for exercise in exercizes:
+            cache.delete(cache_mapper.get_exercise_muscle_bg_key(exercise.pk))
+            for each_set in exercise.set_set.all():
+                reset_workout_canonical_form(each_set.exerciseday.training.pk)
+        
+        super(Muscle, self).delete(*args, **kwargs)
+
+
 
 @python_2_unicode_compatible
 class Equipment(models.Model):

--- a/wger/exercises/signals.py
+++ b/wger/exercises/signals.py
@@ -14,15 +14,19 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 
-from django.db.models.signals import pre_save
-from django.db.models.signals import post_delete
+from django.db.models.signals import pre_save, post_delete
+from django.core.cache import cache, caches
 from django.dispatch import receiver
 from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.signal_handlers import generate_aliases
 from easy_thumbnails.signals import saved_file
 
-from wger.exercises.models import ExerciseImage
+from wger.exercises.models import ExerciseImage, Muscle
 
+@receiver([pre_save, post_delete], sender=Muscle)
+def reset_cache_on_muscle_delete(sender, instance, **kwargs):
+    """ Delete or update the muscle from cache if its deleted or edited """
+    cache.clear()
 
 @receiver(post_delete, sender=ExerciseImage)
 def delete_exercise_image_on_delete(sender, instance, **kwargs):

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -39,6 +39,11 @@ class MuscleListView(ListView):
     context_object_name = 'muscle_list'
     template_name = 'muscles/overview.html'
 
+    def get_queryset(self):
+        if self.template_name == 'muscles/overview.html':
+            return Muscle.objects.all().order_by('-is_front', 'name'),
+        return Muscle.objects.all().order_by('-is_front', 'name')
+
     def get_context_data(self, **kwargs):
         '''
         Send some additional data to the template


### PR DESCRIPTION
## What does this PR do?
This PR fixes the bug where muscles appear in the muscle overview after delete. It as well fixes the bug where old muscle details appear in a muscle list after a muscle has been edited.

## Description of the task to be completed
After a muscle is deleted in the admin overview it appears in the muscle list. If a muscle is edited, its details in the muscle list are not updated. This was due to caching issues. Our task was to therefore reset the cache if a muscle is edited or deleted.

## How can this be manually tested?
   1. Launch the application
   2. Click Exercise drop down menu to reveal Muscles.
   3. Delete a muscle
   4. Click Exercise to revael Muscle overview
  5. The muscle will not appear in the list.

## Relevant pivotal tracker stories?
Bug #154240682

 
