### PR TITLE
Ch relate workout log and session 154240684

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -35,7 +35,7 @@ else:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': '/Users/gatana/wger/wg-tomatoes/database.sqlite',
+            'NAME': './database.sqlite',
             'USER': '',
             'PASSWORD': '',
             'HOST': '',

--- a/wger/manager/models.py
+++ b/wger/manager/models.py
@@ -703,98 +703,6 @@ class Setting(models.Model):
 
 
 @python_2_unicode_compatible
-class WorkoutLog(models.Model):
-    '''
-    A log entry for an exercise
-    '''
-
-    user = models.ForeignKey(User, verbose_name=_('User'), editable=False)
-    exercise = models.ForeignKey(Exercise, verbose_name=_('Exercise'))
-    workout = models.ForeignKey(Workout, verbose_name=_('Workout'))
-
-    repetition_unit = models.ForeignKey(
-        RepetitionUnit, verbose_name=_('Unit'), default=1)
-    '''
-    The unit of the log. This can be e.g. a repetition, a minute, etc.
-    '''
-
-    reps = models.IntegerField(
-        verbose_name=_('Repetitions'), validators=[MinValueValidator(0)])
-    '''
-    Amount of repetitions, minutes, etc.
-
-    Note that since adding the unit field, the name is no longer correct, but is
-    kept for compatibility reasons (specially for the REST API).
-    '''
-
-    weight = models.DecimalField(
-        decimal_places=2,
-        max_digits=5,
-        verbose_name=_('Weight'),
-        validators=[MinValueValidator(0)])
-
-    weight_unit = models.ForeignKey(
-        WeightUnit, verbose_name=_('Unit'), default=1)
-    '''
-    The weight unit of the log. This can be e.g. kg, lb, km/h, etc.
-    '''
-
-    date = Html5DateField(verbose_name=_('Date'))
-
-    # Metaclass to set some other properties
-    class Meta:
-        ordering = ["date", "reps"]
-
-    def __str__(self):
-        '''
-        Return a more human-readable representation
-        '''
-        return u"Log entry: {0} - {1} kg on {2}".format(
-            self.reps, self.weight, self.date)
-
-    def get_owner_object(self):
-        '''
-        Returns the object that has owner information
-        '''
-        return self
-
-    def get_workout_session(self, date=None):
-        '''
-        Returns the corresponding workout session
-
-        :return the WorkoutSession object or None if nothing was found
-        '''
-        if not date:
-            date = self.date
-
-        try:
-            return WorkoutSession.objects.filter(user=self.user).get(date=date)
-        except WorkoutSession.DoesNotExist:
-            return None
-
-    def save(self, *args, **kwargs):
-        '''
-        Reset cache
-        '''
-        reset_workout_log(self.user_id, self.date.year, self.date.month,
-                          self.date.day)
-
-        # If the user selected "Until Failure", do only 1 "repetition",
-        # everythin else doesn't make sense.
-        if self.repetition_unit == 2:
-            self.reps = 1
-        super(WorkoutLog, self).save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        '''
-        Reset cache
-        '''
-        reset_workout_log(self.user_id, self.date.year, self.date.month,
-                          self.date.day)
-        super(WorkoutLog, self).delete(*args, **kwargs)
-
-
-@python_2_unicode_compatible
 class WorkoutSession(models.Model):
     '''
     Model for a workout session
@@ -911,3 +819,96 @@ class WorkoutSession(models.Model):
         '''
         reset_workout_log(self.user_id, self.date.year, self.date.month)
         super(WorkoutSession, self).delete(*args, **kwargs)
+
+@python_2_unicode_compatible
+class WorkoutLog(models.Model):
+    '''
+    A log entry for an exercise
+    '''
+
+    user = models.ForeignKey(User, verbose_name=_('User'), editable=False)
+    exercise = models.ForeignKey(Exercise, verbose_name=_('Exercise'))
+    workout = models.ForeignKey(Workout, verbose_name=_('Workout'))
+
+    repetition_unit = models.ForeignKey(
+        RepetitionUnit, verbose_name=_('Unit'), default=1)
+    '''
+    The unit of the log. This can be e.g. a repetition, a minute, etc.
+    '''
+
+    reps = models.IntegerField(
+        verbose_name=_('Repetitions'), validators=[MinValueValidator(0)])
+    '''
+    Amount of repetitions, minutes, etc.
+
+    Note that since adding the unit field, the name is no longer correct, but is
+    kept for compatibility reasons (specially for the REST API).
+    '''
+    # add a foreign key for workout session
+    workout_session = models.ForeignKey(WorkoutSession, verbose_name=_('workout session'), editable=False, blank=True)
+
+    weight = models.DecimalField(
+        decimal_places=2,
+        max_digits=5,
+        verbose_name=_('Weight'),
+        validators=[MinValueValidator(0)])
+
+    weight_unit = models.ForeignKey(
+        WeightUnit, verbose_name=_('Unit'), default=1)
+    '''
+    The weight unit of the log. This can be e.g. kg, lb, km/h, etc.
+    '''
+
+    date = Html5DateField(verbose_name=_('Date'))
+
+    # Metaclass to set some other properties
+    class Meta:
+        ordering = ["date", "reps"]
+
+    def __str__(self):
+        '''
+        Return a more human-readable representation
+        '''
+        return u"Log entry: {0} - {1} kg on {2}".format(
+            self.reps, self.weight, self.date)
+
+    def get_owner_object(self):
+        '''
+        Returns the object that has owner information
+        '''
+        return self
+
+    def get_workout_session(self, date=None):
+        '''
+        Returns the corresponding workout session
+
+        :return the WorkoutSession object or None if nothing was found
+        '''
+        if not date:
+            date = self.date
+
+        try:
+            return WorkoutSession.objects.filter(user=self.user).get(date=date)
+        except WorkoutSession.DoesNotExist:
+            return None
+
+    def save(self, *args, **kwargs):
+        '''
+        Reset cache
+        '''
+        reset_workout_log(self.user_id, self.date.year, self.date.month,
+                          self.date.day)
+
+        # If the user selected "Until Failure", do only 1 "repetition",
+        # everythin else doesn't make sense.
+        if self.repetition_unit == 2:
+            self.reps = 1
+        super(WorkoutLog, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        '''
+        Reset cache
+        '''
+        reset_workout_log(self.user_id, self.date.year, self.date.month,
+                          self.date.day)
+        super(WorkoutLog, self).delete(*args, **kwargs)

--- a/wger/manager/views/log.py
+++ b/wger/manager/views/log.py
@@ -176,6 +176,7 @@ def add(request, pk):
                 instance.user = request.user
                 instance.workout = day.training
                 instance.date = log_date
+                instance.workout_session = instance.get_workout_session(date=log_date)
                 instance.save()
 
             return HttpResponseRedirect(


### PR DESCRIPTION
#### What does this PR do?
Link the workout logs and the workout session models using a foreign key
#### Description of Task to be completed?

1. Add a foreign key to workoutLog model
2. Reference each workout log created to session by adding an workout-session instance.

#### What are the relevant pivotal tracker stories?
#154240684
#### Screenshots (if appropriate)
workout_session model showing the id of 1

![image](https://user-images.githubusercontent.com/31792736/35670170-c065150e-0748-11e8-91ff-a0150541454d.png)

workout_log model showing a workout_session_id(foreign key) of 1

![image](https://user-images.githubusercontent.com/31792736/35670243-037f7816-0749-11e8-92e6-c223b0086ba0.png)
