### PR TITLE
#154240687 Migrate i18n from Transifex to Pootle

### DIFF
--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -143,9 +143,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://www.transifex.com/rge/wger-workout-manager/">
+                                    <a href="http://127.0.0.1:8000">
                                         <span class="fa fa-external-link" aria-hidden="true"></span>
-                                        {% trans "Translate with Transifex" %}
+                                        {% trans "Translate with Pootle" %}
                                     </a>
                                 </li>
                             </ul>

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -127,7 +127,7 @@
                         {% endfor %}
                         <li class="divider"></li>
                         <li>
-                            <a href="https://www.transifex.com/rge/wger-workout-manager/">
+                            <a href="http://127.0.0.1:8000">
                                 <span class="{% fa_class 'plus' %}"></span>
                                 {% trans "Translate" %}
                             </a>


### PR DESCRIPTION
#### What does this PR do?
Switches the `wger` application from using proprietary `Transifex` for internationalisation(i18n) to using `Pootle`; an open source system that crowd sources it's translations.
#### Description of Task to be completed?
Set up `Pootle` and migrate .po and translation files to `Pootle`.
Edit template files and links that reference `Transifex`.
#### How should this be manually tested?
By checking any of the other links that previously referenced `Transifex`. Please note that one shall need to install and set up `Pootle`.
#### Any background context you want to provide?
The move to `Pootle` from `Transifex` was necessary to keep the application completely open source. However, both services are equally competent.
#### What are the relevant pivotal tracker stories?
#154240687 